### PR TITLE
Fix login issues.

### DIFF
--- a/modules/frontend/frontend/src/AuthCallback.js
+++ b/modules/frontend/frontend/src/AuthCallback.js
@@ -26,24 +26,26 @@ function AuthCallback() {
     navigate('/auth-initiate');
   }
 
-  axios.post(Config.auth.tokenEndpointUrl, queryString.stringify({
-    grant_type: 'authorization_code',
-    client_id: Config.auth.cognitoClientId,
-    redirect_uri: Config.auth.redirectUrl,
-    code: receivedCode,
-    code_challenge_method: 'S256',
-    code_verifier: codeVerifier,
-  }), {
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-  }).then((response) => {
-    const { id_token: idToken, refresh_token: refreshToken } = response.data;
-    handleLogin(idToken, refreshToken);
-    navigate('/');
-  }).catch(() => {
+  React.useEffect(() => {
+    axios.post(Config.auth.tokenEndpointUrl, queryString.stringify({
+      grant_type: 'authorization_code',
+      client_id: Config.auth.cognitoClientId,
+      redirect_uri: Config.auth.redirectUrl,
+      code: receivedCode,
+      code_challenge_method: 'S256',
+      code_verifier: codeVerifier,
+    }), {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    }).then((response) => {
+      const { id_token: idToken, refresh_token: refreshToken } = response.data;
+      handleLogin(idToken, refreshToken);
+      navigate('/');
+    }).catch(() => {
     // eslint-disable-next-line no-console
-    console.error('Auth failed, redirecting to logout.');
-    handleLogout();
-  });
+      console.error('Auth failed, redirecting to logout.');
+      handleLogout();
+    });
+  }, []);
 
   return (
     <div className="AuthCallback">

--- a/modules/frontend/frontend/src/config.js
+++ b/modules/frontend/frontend/src/config.js
@@ -1,4 +1,6 @@
 /* eslint-disable max-len */
+import queryString from 'query-string';
+
 const domain = `${window.location.protocol}//${window.location.host}`;
 const redirectUrl = `${domain}/auth-callback`;
 const apiHost = process.env.REACT_APP_API_HOST;
@@ -21,10 +23,16 @@ const Config = {
     // SPLoginUrl: `${cognitoHost}/login?response_type=token&client_id=${cognitoClientId}&redirect_uri=${redirectUrl}&scope=openid+profile`,
     // Short circuting the cognito authentication selection to use the Cognito-provided OAuth with a SAML identity provider
     // The url is still missing an oauth PKCE verifier and state params, added by the application
-    getLoginUrl: (identityProvider, authState, codeChallenge) => `${cognitoHost}/oauth2/authorize`
-     + `?response_type=code&client_id=${cognitoClientId}&redirect_uri=${redirectUrl}`
-     + `&scope=openid profile&code_challenge_method=S256&identity_provider=${identityProvider}`
-     + `&state=${authState}&code_challenge=${codeChallenge}`,
+    getLoginUrl: (identityProvider, authState, codeChallenge) => `${cognitoHost}/oauth2/authorize?${queryString.stringify({
+      response_type: 'code',
+      client_id: cognitoClientId,
+      redirect_uri: redirectUrl,
+      scope: 'openid profile',
+      code_challenge_method: 'S256',
+      identity_provider: identityProvider,
+      state: authState,
+      code_challenge: codeChallenge,
+    })}`,
     tokenEndpointUrl: `${cognitoHost}/oauth2/token`,
   },
 };


### PR DESCRIPTION
`AuthCallback` component would re-render causing it to try to fetch the token twice, and one of the requests would always fail (as the code is single use only). 
These changes ensure the token is only fetched once.