### PR TITLE
Terraform variable allocation of labels and minor bugfixes

### DIFF
--- a/modules/backend-ecr/private-api-ecr-image.tf
+++ b/modules/backend-ecr/private-api-ecr-image.tf
@@ -14,6 +14,10 @@ resource "docker_image" "private_api" {
     target     = "production_private_api"
     build_args = {
       INSTALL_PYTHON_VERSION = 3.9
+      PIP_INDEX_URL          = var.pip_index_url
+      http_proxy             = var.http_proxy
+      https_proxy            = var.https_proxy
+      no_proxy               = var.no_proxy
     }
     tag = [aws_ecr_repository.private_api.repository_url]
   }

--- a/modules/backend-ecr/public-api-ecr-image.tf
+++ b/modules/backend-ecr/public-api-ecr-image.tf
@@ -14,6 +14,10 @@ resource "docker_image" "public_api" {
     target     = "production_public_api"
     build_args = {
       INSTALL_PYTHON_VERSION = 3.9
+      PIP_INDEX_URL          = var.pip_index_url
+      http_proxy             = var.http_proxy
+      https_proxy            = var.https_proxy
+      no_proxy               = var.no_proxy
     }
     tag = [aws_ecr_repository.public_api.repository_url]
   }

--- a/modules/backend-ecr/quail-api/Dockerfile
+++ b/modules/backend-ecr/quail-api/Dockerfile
@@ -14,6 +14,11 @@ RUN addgroup --system quail \
     && adduser --system --ingroup quail quail
 RUN chown quail:quail /app
 
+# set optional environment variables for proxy
+ARG http_proxy=""
+ARG https_proxy=""
+ARG no_proxy=""
+
 # Install system-level packages
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -21,6 +26,7 @@ RUN apt-get update && \
       python3-dev
 
 # Update pip
+ARG PIP_INDEX_URL="https://pypi.python.org/simple"
 RUN pip install --upgrade pip
 
 # Install production level requirements

--- a/modules/backend-ecr/quail-api/backend/private_api/views.py
+++ b/modules/backend-ecr/quail-api/backend/private_api/views.py
@@ -113,7 +113,7 @@ def post_notify_failure():
     stackset_email = payload["stackset_email"]
 
     # send SNS failure notification
-    current_app.aws.send_sns_message(stackset_id=stackset_id)
+    current_app.aws.send_error_sns_message(stackset_id=stackset_id)
 
     for instance_data in current_app.aws.fetch_stackset_instances(stackset_id=stackset_id, acceptable_statuses=None):
         template_data = {

--- a/modules/backend-ecr/variables.tf
+++ b/modules/backend-ecr/variables.tf
@@ -18,3 +18,27 @@ variable "resource-tags" {
   default     = {}
   description = "Tags to assign to resources provisioned by terraform. Apart from the listed tags, a {part_of: $${project-name}} tag is assigned to all resources."
 }
+
+variable "http_proxy" {
+  type        = string
+  default     = ""
+  description = "Sets http_proxy environment variable during docker build. Useful for airgapped environments that require a proxy."
+}
+
+variable "https_proxy" {
+  type        = string
+  default     = ""
+  description = "Sets https_proxy environment variable during docker build. Useful for airgapped environments that require a proxy."
+}
+
+variable "no_proxy" {
+  type        = string
+  default     = ""
+  description = "Sets no_proxy environment variable during docker build. Useful for airgapped environments that require a proxy."
+}
+
+variable "pip_index_url" {
+  type        = string
+  default     = "https://pypi.python.org/simple"
+  description = "Optional base URL for PyPI that pip uses to fetch python packages during docker build."
+}

--- a/modules/backend/private-api-lambda.tf
+++ b/modules/backend/private-api-lambda.tf
@@ -46,15 +46,18 @@ data "aws_iam_policy_document" "private_api" {
     resources = [aws_iam_role.stackset_admin_role.arn]
   }
 
-  # Permissions to assume roles in remote accounts
-  statement {
-    effect = "Allow"
-    actions = [
-      "sts:AssumeRole",
-    ]
-    resources = [
-      for account_id in var.remote-accounts : "arn:aws:iam::${account_id}:role/${var.cross-account-role-name}"
-    ]
+  # Permissions to assume roles in remote accounts. Only created if remote-accounts is set.
+  dynamic "statement" {
+   for_each = length(var.remote-accounts) > 0 ? [1] : []
+   content {
+     effect = "Allow"
+     actions = [
+       "sts:AssumeRole",
+     ]
+     resources = [
+       for account_id in var.remote-accounts : "arn:aws:iam::${account_id}:role/${var.cross-account-role-name}"
+     ]
+   }
   }
 
   # S3 permissions

--- a/modules/backend/public-api-lambda.tf
+++ b/modules/backend/public-api-lambda.tf
@@ -34,15 +34,18 @@ data "aws_iam_policy_document" "public_api" {
     resources = [aws_iam_role.stackset_admin_role.arn]
   }
 
-  # Permissions to assume roles in remote accounts
-  statement {
-    effect = "Allow"
-    actions = [
-      "sts:AssumeRole",
-    ]
-    resources = [
-      for account_id in var.remote-accounts : "arn:aws:iam::${account_id}:role/${var.cross-account-role-name}"
-    ]
+  # Permissions to assume roles in remote accounts. Only created if remote-accounts is set.
+  dynamic "statement" {
+    for_each = length(var.remote-accounts) > 0 ? [1] : []
+    content {
+      effect = "Allow"
+      actions = [
+        "sts:AssumeRole",
+      ]
+      resources = [
+        for account_id in var.remote-accounts : "arn:aws:iam::${account_id}:role/${var.cross-account-role-name}"
+      ]
+    }
   }
 
   # DynamoDB-related permissions

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -69,6 +69,7 @@ variable "cross-account-role-name" {
 variable "remote-accounts" {
   type        = list(string)
   description = "List of account IDs where users can provision instances (excl. the main account)."
+  default     = []
 }
 
 variable "stack-set-execution-role-name" {

--- a/modules/frontend-ecr/ecr-image.tf
+++ b/modules/frontend-ecr/ecr-image.tf
@@ -28,7 +28,10 @@ resource "docker_image" "nginx" {
   build {
     context    = path.module
     dockerfile = "nginx/Dockerfile"
-    tag        = [aws_ecr_repository.react_frontend.repository_url]
+    build_args = {
+      NPM_CONFIG_REGISTRY = var.npm_registry_url
+    }
+    tag = [aws_ecr_repository.react_frontend.repository_url]
   }
 
   triggers = {

--- a/modules/frontend-ecr/ecr-image.tf
+++ b/modules/frontend-ecr/ecr-image.tf
@@ -37,7 +37,7 @@ resource "docker_image" "nginx" {
       join("", [for f in concat(
         tolist(fileset(".", "${path.module}/frontend/src/**")),
         tolist(fileset(".", "${path.module}/frontend/public/**")),
-        tolist(fileset(".", "${path.module}/frontend/public/.env")),
+        tolist(fileset(".", "${path.module}/frontend/.env")),
         [
           "${path.module}/frontend/package.json",
           "${path.module}/frontend/package-lock.json"

--- a/modules/frontend-ecr/ecr-image.tf
+++ b/modules/frontend-ecr/ecr-image.tf
@@ -5,7 +5,10 @@ locals {
   REACT_APP_API_HOST=${var.api-root-url}
   REACT_APP_JWT_ISSUER=${var.jwt-issuer}
   REACT_APP_JWT_CLIENT_ID=${var.jwt-client-id}
+  REACT_APP_ADMIN_GROUP_NAME=${var.admin-group-name}
+  REACT_APP_REGION_LABELS=${jsonencode(var.region-name-labels)}
   REACT_APP_ACCOUNT_LABELS=${jsonencode(var.account-name-labels)}
+  REACT_APP_INSTANCE_LABELS=${jsonencode(var.instance-name-labels)}
   EOT
 }
 

--- a/modules/frontend-ecr/frontend/src/components/ConfigsTable.js
+++ b/modules/frontend-ecr/frontend/src/components/ConfigsTable.js
@@ -53,10 +53,10 @@ export default function ConfigsTable(props) {
                 {Config.accountLabels[config.account] || config.account}
               </TableCell>
               <TableCell className={classes.tableCell}>
-                { getLabel('regions', config.region) }
+                { getLabel('regionLabels', config.region) }
               </TableCell>
               <TableCell className={classes.tableCell}>
-                { getLabel('instanceTypes', config.instanceType) }
+                { getLabel('instanceLabels', config.instanceType) }
               </TableCell>
               <TableCell className={classes.tableCell}>{config.operatingSystem}</TableCell>
               <TableCell className={classes.tableCell}>{formatDate(config.expiry)}</TableCell>

--- a/modules/frontend-ecr/frontend/src/components/ConfigsTable.js
+++ b/modules/frontend-ecr/frontend/src/components/ConfigsTable.js
@@ -50,7 +50,7 @@ export default function ConfigsTable(props) {
               onClick={() => onRestoreClick(config)}
             >
               <TableCell className={classes.tableCell}>
-                {Config.accountLabels[config.account] || config.account}
+                { getLabel('accountLabels', config.account) }
               </TableCell>
               <TableCell className={classes.tableCell}>
                 { getLabel('regionLabels', config.region) }

--- a/modules/frontend-ecr/frontend/src/components/InstanceForm.js
+++ b/modules/frontend-ecr/frontend/src/components/InstanceForm.js
@@ -11,7 +11,6 @@ import { Alert } from '@mui/lab';
 
 import SelectField from './SelectField';
 import DebouncedButton from './DebouncedButton';
-import labels from '../labels';
 import Config from '../config';
 import { formatDate } from '../utils';
 
@@ -125,7 +124,7 @@ const InstanceForm = (props) => {
               label="Region"
               fieldName="selectedRegion"
               values={regions}
-              valueLabels={labels.regions}
+              valueLabels={Config.regionLabels}
               selected={selectedRegion}
               onFieldChange={onFieldChange}
               disabled={formDisabled}
@@ -138,7 +137,7 @@ const InstanceForm = (props) => {
               label="Instance Type"
               fieldName="instanceType"
               values={instanceTypes}
-              valueLabels={labels.instanceTypes}
+              valueLabels={Config.instanceLabels}
               selected={selectedInstanceType}
               disabled={formDisabled}
               onFieldChange={onFieldChange}

--- a/modules/frontend-ecr/frontend/src/components/InstancesTable.js
+++ b/modules/frontend-ecr/frontend/src/components/InstancesTable.js
@@ -25,8 +25,7 @@ import { enqueueSnackbar } from 'notistack';
 
 import { debounce } from 'lodash';
 import SelectField from './SelectField';
-import { getLabel, formatDate, getUserData } from '../utils';
-import labels from '../labels';
+import { formatDate, getUserData } from '../utils';
 import Config from '../config';
 
 const GridActionsCellItemWrapper = (params) => {
@@ -112,7 +111,10 @@ export default function InstancesTable(props) {
       valueFormatter: ({ value: account_id }) => Config.accountLabels[account_id] || account_id,
     },
     {
-      field: 'region', headerName: 'Region', minWidth: 150, valueFormatter: ({ value: region }) => getLabel('regions', region),
+      field: 'region',
+      headerName: 'Region',
+      minWidth: 150,
+      valueFormatter: ({ value: region }) => Config.regionLabels[region] || region,
     },
     {
       field: 'instanceType',
@@ -123,7 +125,7 @@ export default function InstancesTable(props) {
         <SelectField
           fieldName="instanceType"
           values={instanceTypes}
-          valueLabels={labels.instanceTypes}
+          valueLabels={Config.instanceLabels}
           selected={value}
           disabled={instance.state !== 'running' && instance.state !== 'stopped'}
           onFieldChange={(event) => handleClickOpen(instance, event.target.value)}

--- a/modules/frontend-ecr/frontend/src/components/InstancesTable.js
+++ b/modules/frontend-ecr/frontend/src/components/InstancesTable.js
@@ -25,7 +25,7 @@ import { enqueueSnackbar } from 'notistack';
 
 import { debounce } from 'lodash';
 import SelectField from './SelectField';
-import { formatDate, getUserData } from '../utils';
+import { formatDate, getLabel, getUserData } from '../utils';
 import Config from '../config';
 
 const GridActionsCellItemWrapper = (params) => {
@@ -108,13 +108,13 @@ export default function InstancesTable(props) {
     {
       field: 'account_id',
       headerName: 'Account',
-      valueFormatter: ({ value: account_id }) => Config.accountLabels[account_id] || account_id,
+      valueFormatter: ({ value: account_id }) => getLabel('accountLabels', account_id),
     },
     {
       field: 'region',
       headerName: 'Region',
       minWidth: 150,
-      valueFormatter: ({ value: region }) => Config.regionLabels[region] || region,
+      valueFormatter: ({ value: region }) => getLabel('regionLabels', region),
     },
     {
       field: 'instanceType',

--- a/modules/frontend-ecr/frontend/src/config.js
+++ b/modules/frontend-ecr/frontend/src/config.js
@@ -5,10 +5,10 @@ const CLIENT_ID = process.env.REACT_APP_JWT_CLIENT_ID;
 const ISSUER = process.env.REACT_APP_JWT_ISSUER;
 const OKTA_TESTING_DISABLEHTTPSCHECK = window.location.origin.includes('localhost');
 const REDIRECT_URI = `${window.location.origin}/login/callback`;
-const REGION_LABELS = JSON.parse(process.env.REACT_APP_REGION_LABELS || '{}');
-const ACCOUNT_LABELS = JSON.parse(process.env.REACT_APP_ACCOUNT_LABELS || '{}');
-const INSTANCE_LABELS = JSON.parse(process.env.REACT_APP_INSTANCE_LABELS || '{}');
-const ADMIN_GROUP_NAME = process.env.REACT_APP_ADMIN_GROUP_NAME || 'quail-admins';
+const REGION_LABELS = JSON.parse(process.env.REACT_APP_REGION_LABELS);
+const ACCOUNT_LABELS = JSON.parse(process.env.REACT_APP_ACCOUNT_LABELS);
+const INSTANCE_LABELS = JSON.parse(process.env.REACT_APP_INSTANCE_LABELS);
+const ADMIN_GROUP_NAME = process.env.REACT_APP_ADMIN_GROUP_NAME;
 
 const Config = {
   domain,

--- a/modules/frontend-ecr/frontend/src/config.js
+++ b/modules/frontend-ecr/frontend/src/config.js
@@ -1,13 +1,14 @@
 const domain = `${window.location.protocol}//${window.location.host}`;
 const apiHost = process.env.REACT_APP_API_HOST;
 
-// const CLIENT_ID = '0oa9w825dhkMgNA1Q5d7';
-// const ISSUER = 'https://dev-36256492.okta.com/oauth2/aus9w7yu8qX5yboZX5d7';
 const CLIENT_ID = process.env.REACT_APP_JWT_CLIENT_ID;
 const ISSUER = process.env.REACT_APP_JWT_ISSUER;
 const OKTA_TESTING_DISABLEHTTPSCHECK = window.location.origin.includes('localhost');
 const REDIRECT_URI = `${window.location.origin}/login/callback`;
+const REGION_LABELS = JSON.parse(process.env.REACT_APP_REGION_LABELS || '{}');
 const ACCOUNT_LABELS = JSON.parse(process.env.REACT_APP_ACCOUNT_LABELS || '{}');
+const INSTANCE_LABELS = JSON.parse(process.env.REACT_APP_INSTANCE_LABELS || '{}');
+const ADMIN_GROUP_NAME = process.env.REACT_APP_ADMIN_GROUP_NAME || 'quail-admins';
 
 const Config = {
   domain,
@@ -22,7 +23,10 @@ const Config = {
     pkce: true,
     disableHttpsCheck: OKTA_TESTING_DISABLEHTTPSCHECK,
   },
+  regionLabels: REGION_LABELS,
   accountLabels: ACCOUNT_LABELS,
+  instanceLabels: INSTANCE_LABELS,
+  adminGroupName: ADMIN_GROUP_NAME,
 };
 
 export default Config;

--- a/modules/frontend-ecr/frontend/src/utils.js
+++ b/modules/frontend-ecr/frontend/src/utils.js
@@ -1,5 +1,5 @@
 import { useOktaAuth } from '@okta/okta-react';
-import labels from './labels';
+import Config from './config';
 
 function saveConfigurations(configurations) {
   localStorage.setItem('previous_configs', JSON.stringify(configurations));
@@ -16,7 +16,7 @@ function formatDate(date) {
 }
 
 function getLabel(type, key) {
-  return key in labels[type] ? labels[type][key] : key;
+  return key in Config[type] ? Config[type][key] : key;
 }
 
 const getUserData = () => {
@@ -27,7 +27,7 @@ const getUserData = () => {
     username: token?.claims?.name,
     email: token?.claims?.email,
     groups: token?.claims?.groups.join(', '),
-    is_superuser: !!token?.claims?.groups.includes('quail-admins'),
+    is_superuser: !!token?.claims?.groups.includes(Config.adminGroupName),
   };
 };
 

--- a/modules/frontend-ecr/nginx/Dockerfile
+++ b/modules/frontend-ecr/nginx/Dockerfile
@@ -4,6 +4,8 @@ FROM node:16 as build
 WORKDIR /app
 
 COPY frontend/package*.json /app/
+
+ARG NPM_CONFIG_REGISTRY="https://registry.npmjs.org"
 RUN npm install --package-lock=true --production=false
 
 COPY frontend/.* *.json /app/

--- a/modules/frontend-ecr/variables.tf
+++ b/modules/frontend-ecr/variables.tf
@@ -40,3 +40,9 @@ variable "account-name-labels" {
   default     = {}
   description = "Mapping of AWS account IDs to user friendly names."
 }
+
+variable "npm_registry_url" {
+  type        = string
+  default     = "https://registry.npmjs.org"
+  description = "URL for alternative NPM registry to obtain remote packages"
+}

--- a/modules/frontend-ecr/variables.tf
+++ b/modules/frontend-ecr/variables.tf
@@ -35,14 +35,58 @@ variable "jwt-client-id" {
   description = "ID of the OAuth client App."
 }
 
-variable "account-name-labels" {
-  type        = map(string)
-  default     = {}
-  description = "Mapping of AWS account IDs to user friendly names."
-}
-
 variable "npm_registry_url" {
   type        = string
   default     = "https://registry.npmjs.org"
   description = "URL for alternative NPM registry to obtain remote packages"
+}
+
+variable "admin-group-name" {
+  type        = string
+  default     = "quail-admins"
+  description = "Name of the admins Okta group."
+}
+
+ variable "account-name-labels" {
+   type        = map(string)
+   default     = {}
+   description = "Mapping of AWS account IDs to user friendly names."
+ }
+
+variable "region-name-labels" {
+  type = map(string)
+  default = {
+    "us-east-1"      = "US East (N. Virginia)",
+    "us-east-2"      = "US East (Ohio)",
+    "us-west-1"      = "US West (N. California)",
+    "us-west-2"      = "US West (Oregon)",
+    "af-south-1"     = "Africa (Cape Town)",
+    "ap-east-1"      = "Asia Pacific (Hong Kong)",
+    "ap-south-1"     = "Asia Pacific (Mumbai)",
+    "ap-southeast-1" = "Asia Pacific (Singapore)",
+    "ap-southeast-2" = "Asia Pacific (Sydney)",
+    "ap-northeast-1" = "Asia Pacific (Tokyo)",
+    "ap-northeast-2" = "Asia Pacific (Seoul)",
+    "ap-northeast-3" = "Asia Pacific (Osaka-Local)",
+    "ca-central-1"   = "Canada (Central)",
+    "eu-central-1"   = "Europe (Frankfurt)",
+    "eu-west-1"      = "Europe (Ireland)",
+    "eu-west-2"      = "Europe (London)",
+    "eu-west-3"      = "Europe (Paris)",
+    "eu-south-1"     = "Europe (Milan)",
+    "eu-north-1"     = "Europe (Stockholm)",
+    "me-south-1"     = "Middle East (Bahrain)",
+    "sa-east-1"      = "South America (São Paulo)",
+  }
+  description = "Mapping of AWS EC2 region names to user friendly names."
+}
+
+variable "instance-name-labels" {
+  type = map(string)
+  default = {
+    "t3.nano"  = "t3.nano (2vCPU/0.5GB)",
+    "t3.micro" = "t3.micro (2vCPU/1GB)",
+    "t3.small" = "t3.small (2vCPU/2GB)",
+  }
+  description = "Mapping of AWS EC2 Instance types to user friendly names."
 }


### PR DESCRIPTION
This PR does a few things:
 - Allows proxy and package registry variables to be set for during the docker build process. Useful for semi-airgapped environments that do not allow direct access to the internet.
 - Made labels dynamically allocatable, meaning you can update these via terraform rather than within the app source code.
 - Previously at least one remote account was required for Quail to deploy, and this is now optional
 - Fixed an error that prevented rebuilds when the .env changed
 - Fixed an error that wouldn't successfully send a failure email